### PR TITLE
Fix limbqomx_jpegenc.so loading

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -90,6 +90,7 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     Snap \
     camera.msm8916 \
+    libboringssl-compat \
     libmm-qcamera
 
 # GPS HAL

--- a/rootdir/main/init.qcom.rc
+++ b/rootdir/main/init.qcom.rc
@@ -43,7 +43,7 @@ on early-init
     symlink /data/tombstones /tombstones
 
 on init
-    export LD_SHIM_LIBS /system/lib/libril.so|libril_shim.so
+    export LD_SHIM_LIBS /system/vendor/lib/libqomx_jpegenc.so|libboringssl-compat.so:/system/lib/libril.so|libril_shim.so
 
     # Set permissions for persist partition
     mkdir /persist 0771 system system


### PR DESCRIPTION
Our jpeg encoding library is considered legacy in Marshmallow. We need
to shim it with libboringssl-compat for it to actually load. It fixes camera photo saving.